### PR TITLE
Added new command to run tests in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
                 "title": "MavensMate: Run Apex Tests"
             },
             {
+                "command": "mavensmate.runTestsAsync",
+                "title": "MavensMate: Run Tests In Editor (async)"
+            },
+            {
                 "command": "mavensmate.openSalesforce",
                 "title": "MavensMate: Open Salesforce"
             },

--- a/src/mavensmate/commands/runTestsAsync.ts
+++ b/src/mavensmate/commands/runTestsAsync.ts
@@ -1,0 +1,84 @@
+import { ClientCommand } from './clientCommand';
+import * as vscode from 'vscode';
+import Promise = require('bluebird');
+import path = require('path');
+
+
+class RunTestsAsync extends ClientCommand {
+    filePath: string;
+    baseName: string;
+
+    static create() {
+        return new RunTestsAsync();
+    }
+
+    constructor() {
+        super('Run Apex Tests', 'run-tests');
+        this.async = true;
+        this.body.args.ui = false;
+    }
+
+    execute(selectedResource?: vscode.Uri): Thenable<any> {
+        if(selectedResource && selectedResource.scheme === 'file'){
+            this.filePath = selectedResource.fsPath;
+        } else if(vscode.window.activeTextEditor && vscode.window.activeTextEditor.document) {
+            this.filePath = vscode.window.activeTextEditor.document.uri.fsPath;
+        }
+        return this.confirmPath()
+            .then(() => {
+                this.body.classes = [this.baseName];
+                return super.execute();
+            });
+    }
+
+    protected confirmPath(): Thenable<any> {
+        if(this.filePath && this.filePath.length > 0){
+            this.baseName = path.basename(this.filePath, '.cls');
+        }
+        return Promise.resolve();
+    }
+
+    onStart(): Promise<any>{
+        return super.onStart()
+            .then(() => {
+                return this.outputPathProcessed();
+            });
+    }
+
+    private outputPathProcessed(){
+        if(this.baseName && this.filePath){
+            let message = `${this.baseName} (${this.filePath})`
+            return this.mavensMateChannel.appendLine(message);
+        } else {
+            return Promise.resolve();
+        }
+    }
+
+    onSuccess(response): Promise<any> {
+        return super.onSuccess(response)
+            .then(() => {
+                this.outputPathProcessed();
+                let classResults = response.result.testResults[this.baseName];
+                this.mavensMateChannel.appendLine(classResults.ExtendedStatus, classResults.Status);
+                for(let i = 0; i < classResults.results.length; i++){
+                    let testResult = classResults.results[i];
+                    this.mavensMateChannel.appendLine(testResult.MethodName, testResult.Outcome);
+                    if(testResult.Outcome == 'Fail'){
+                        this.mavensMateChannel.appendLine(testResult.Message);
+                        this.mavensMateChannel.appendLine(testResult.StackTrace);
+                    }
+                }
+                return response;
+        });
+    }
+
+    onFailure(response): Promise<any> {
+        return super.onFailure(response)
+            .then(() => {
+                this.outputPathProcessed().then(response);
+                return response;
+            });
+    }
+}
+
+export = RunTestsAsync;


### PR DESCRIPTION
Currently the output channel is closed after tests finish which is a little weird.  Could improve experience by moving the results to the error panel (maybe as `warning` or `information`).  

Alternatively, `MavensMateChannel` &  `ClientCommand` could be modified to permit the channel to stay open after command finishes