### PR TITLE
Allow CSS files to be compiled on save, and make tests run on Windows

### DIFF
--- a/src/mavensmate/commands/compileFile.ts
+++ b/src/mavensmate/commands/compileFile.ts
@@ -5,7 +5,7 @@ import { handleCompileResponse } from '../handlers/compileResponseHandler';
 import * as vscode from 'vscode';
 import Promise = require('bluebird');
 
-let languagesToCompileOnSave = new Set<string>(['apex', 'visualforce', 'xml', 'javascript']);
+let languagesToCompileOnSave = new Set<string>(['apex', 'visualforce', 'xml', 'javascript', 'css']);
 
 class CompileFile extends PathsCommand {
     static create(label?: string): PathsCommand{

--- a/src/mavensmate/projectSettings.ts
+++ b/src/mavensmate/projectSettings.ts
@@ -28,7 +28,8 @@ export class ProjectSettings {
         if(!ProjectSettings._instances[projectPath]){
             ProjectSettings.getProjectSettings(projectPath);
         }
-        return ProjectSettings._instances[projectPath] !== null;
+        return ProjectSettings._instances[projectPath] !== null 
+            && ProjectSettings._instances[projectPath] !== undefined;
     }
 }
 

--- a/test/mavensmate/mavensMateAppConfig.test.ts
+++ b/test/mavensmate/mavensMateAppConfig.test.ts
@@ -1,5 +1,6 @@
 import assert = require('assert');
 import sinon = require('sinon');
+import path = require('path');
 
 import operatingSystem = require('../../src/workspace/operatingSystem');
 import jsonFile = require('../../src/workspace/jsonFile');
@@ -23,8 +24,8 @@ suite('mavensMate App Config', () => {
         process.env.HOME = 'hometest';
         
         openStub = sinon.stub(jsonFile, 'open');
-        openStub.withArgs('userprofiletest/.mavensmate-config.json').returns(windowsJson);
-        openStub.withArgs('hometest/.mavensmate-config.json').returns(nonWindowsJson); 
+        openStub.withArgs(path.normalize('userprofiletest/.mavensmate-config.json')).returns(windowsJson);
+        openStub.withArgs(path.normalize('hometest/.mavensmate-config.json')).returns(nonWindowsJson); 
     });
     
     teardown(() => { 
@@ -43,8 +44,8 @@ suite('mavensMate App Config', () => {
         test('it uses home', () => {
             mavensMateAppConfig.getConfig();
             
-            sinon.assert.calledWith(openStub, 'hometest/.mavensmate-config.json');
-            sinon.assert.neverCalledWith(openStub, 'userprofiletest/.mavensmate-config.json');
+            sinon.assert.calledWith(openStub, path.normalize('hometest/.mavensmate-config.json'));
+            sinon.assert.neverCalledWith(openStub, path.normalize('userprofiletest/.mavensmate-config.json'));
         });
         
         test('it parses correct json', () => {
@@ -70,8 +71,8 @@ suite('mavensMate App Config', () => {
         test('it uses userprofile', () => {
             mavensMateAppConfig.getConfig();
             
-            sinon.assert.calledWith(openStub, 'userprofiletest/.mavensmate-config.json');
-            sinon.assert.neverCalledWith(openStub, 'hometest/.mavensmate-config.json');
+            sinon.assert.calledWith(openStub, path.normalize('userprofiletest/.mavensmate-config.json'));
+            sinon.assert.neverCalledWith(openStub, path.normalize('hometest/.mavensmate-config.json'));
         });
         
         test('it parses correct json', () => {
@@ -97,8 +98,8 @@ suite('mavensMate App Config', () => {
         test('it uses home', () => {
             mavensMateAppConfig.getConfig();
             
-            sinon.assert.calledWith(openStub, 'hometest/.mavensmate-config.json');
-            sinon.assert.neverCalledWith(openStub, 'userprofiletest/.mavensmate-config.json');
+            sinon.assert.calledWith(openStub, path.normalize('hometest/.mavensmate-config.json'));
+            sinon.assert.neverCalledWith(openStub, path.normalize('userprofiletest/.mavensmate-config.json'));
         });
         
         test('it parses correct json', () => {

--- a/test/workspace/projectList.test.ts
+++ b/test/workspace/projectList.test.ts
@@ -1,6 +1,7 @@
 import assert = require('assert');
 import sinon = require('sinon');
 import fs = require('fs-promise');
+import path = require('path');
 
 import jsonFile = require('../../src/workspace/jsonFile');
 import { ProjectSettings } from '../../src/mavensmate/projectSettings';
@@ -35,11 +36,11 @@ suite('projectList', () => {
         readDirStub.withArgs('missingWorkspace').returns(Promise.reject('missingWorkspace is missing as intended'));
         
         jsonFileStub = sinon.stub(jsonFile, 'open');
-        jsonFileStub.withArgs('workspace1/project1/config/.settings').returns(testSettings);
-        jsonFileStub.withArgs('workspace1/project2/config/.settings').returns(testSettings);
-        jsonFileStub.withArgs('workspace2/project1/config/.settings').returns(testSettings);
-        jsonFileStub.withArgs('workspace2/project3/config/.settings').returns(testSettings);
-        jsonFileStub.withArgs('workspace2/doesNotExist/config/.settings').returns(null);
+        jsonFileStub.withArgs(path.normalize('workspace1/project1/config/.settings')).returns(testSettings);
+        jsonFileStub.withArgs(path.normalize('workspace1/project2/config/.settings')).returns(testSettings);
+        jsonFileStub.withArgs(path.normalize('workspace2/project1/config/.settings')).returns(testSettings);
+        jsonFileStub.withArgs(path.normalize('workspace2/project3/config/.settings')).returns(testSettings);
+        jsonFileStub.withArgs(path.normalize('workspace2/doesNotExist/config/.settings')).returns(null);
     });
     
     teardown(() => {
@@ -51,10 +52,10 @@ suite('projectList', () => {
     test('gets the 4 actual projects', (testDone) => {
         projectList.promiseList().then((projects) => {
                 assert.equal(projects.length, 4);
-                assertIsProject(projects[0], 'project1', 'workspace1/project1', 'workspace1');
-                assertIsProject(projects[1], 'project2', 'workspace1/project2', 'workspace1');
-                assertIsProject(projects[2], 'project1', 'workspace2/project1', 'workspace2');
-                assertIsProject(projects[3], 'project3', 'workspace2/project3', 'workspace2');
+                assertIsProject(projects[0], 'project1', path.normalize('workspace1/project1'), 'workspace1');
+                assertIsProject(projects[1], 'project2', path.normalize('workspace1/project2'), 'workspace1');
+                assertIsProject(projects[2], 'project1', path.normalize('workspace2/project1'), 'workspace2');
+                assertIsProject(projects[3], 'project3', path.normalize('workspace2/project3'), 'workspace2');
             })
             .done(testDone, console.error);
     });


### PR DESCRIPTION
I noticed that the VSCode plugin for Mavensmate didn't compile CSS files for Aura / Lightning components. 

I couldn't run it with F5 straight up as it errored trying to load a non-existent settings file. So I fixed that. 

Then I added the css type to the auto-compile types (it still bails if they are found in a resource-bundle, same as javascript).

Then I thought I'd run the tests, and found that they didn't pass on Windows. So I started fixing them. Got most of them done, but the activation tests I couldn't grok. I don't undertand mocha / sinon enough to say whether the activation checks should be triggered, and I don't have an OSX / Linux machine at the moment to test if these tests are broken only in Windows?

Anyway please merge this and pop a release out so that I can carry on using VSCode and not have to go over to Atom or something!